### PR TITLE
Fix on_shutdown

### DIFF
--- a/lib/padrino-websockets/base-event-manager.rb
+++ b/lib/padrino-websockets/base-event-manager.rb
@@ -124,7 +124,7 @@ module Padrino
       #
       def on_shutdown
         logger.debug "Disconnecting user: #{@user} from channel: #{@channel}."
-        @@connections[@channel].delete(@ws)
+        @@connections[@channel].delete(@user)
       end
 
       class << self

--- a/lib/padrino-websockets/faye/event-manager.rb
+++ b/lib/padrino-websockets/faye/event-manager.rb
@@ -21,6 +21,7 @@ module Padrino
         #
         def on_shutdown(event)
           @pinger.cancel if @pinger
+          super
         end
 
         ##

--- a/lib/padrino-websockets/version.rb
+++ b/lib/padrino-websockets/version.rb
@@ -1,5 +1,5 @@
 module Padrino
   module Websockets
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Fixed on_shutdown to call parent in faye and to delete the right thing (the user) when clsoing the connection on the channel.

Fixes #5.