### PR TITLE
add basic pub-sub support to event managers

### DIFF
--- a/lib/padrino-websockets.rb
+++ b/lib/padrino-websockets.rb
@@ -13,17 +13,22 @@ module Padrino
       #
       def registered(app)
         require 'padrino-websockets/base-event-manager'
+        require 'padrino-websockets/pub_sub'
+        # set default pubsub,  initializer can override w/ different impl
+
 
         if defined?(::SpiderGazelle)
           require 'padrino-websockets/spider-gazelle'
           app.helpers Padrino::WebSockets::SpiderGazelle::Helpers
           app.extend Padrino::WebSockets::SpiderGazelle::Routing
+          Padrino::WebSockets::SpiderGazelle::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
         elsif defined?(::Faye::WebSocket)
           require 'padrino-websockets/faye'
           ::Faye::WebSocket.load_adapter('thin') if defined?(::Thin)
           require 'padrino-websockets/faye/puma-patch' if defined?(Puma)
           app.helpers Padrino::WebSockets::Faye::Helpers
           app.extend Padrino::WebSockets::Faye::Routing
+          Padrino::WebSockets::Faye::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
         else
           logger.error %Q{Can't find a WebSockets backend. At the moment we only support
             SpiderGazelle and Faye Websockets friendly application backends (Puma and Thin work,

--- a/lib/padrino-websockets.rb
+++ b/lib/padrino-websockets.rb
@@ -14,13 +14,16 @@ module Padrino
       def registered(app)
         require 'padrino-websockets/base-event-manager'
         require 'padrino-websockets/pub_sub'
-        # set default pubsub,  initializer can override w/ different impl
-
+        # set default pubsub to in-memory.  initializer can override with a different
+        # implementation
 
         if defined?(::SpiderGazelle)
           require 'padrino-websockets/spider-gazelle'
           app.helpers Padrino::WebSockets::SpiderGazelle::Helpers
           app.extend Padrino::WebSockets::SpiderGazelle::Routing
+          
+          # set default pubsub to in-memory.  initializer can override with a different
+          # implementation
           Padrino::WebSockets::SpiderGazelle::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
         elsif defined?(::Faye::WebSocket)
           require 'padrino-websockets/faye'
@@ -28,6 +31,9 @@ module Padrino
           require 'padrino-websockets/faye/puma-patch' if defined?(Puma)
           app.helpers Padrino::WebSockets::Faye::Helpers
           app.extend Padrino::WebSockets::Faye::Routing
+
+          # set default pubsub to in-memory.  initializer can override with a different
+          # implementation
           Padrino::WebSockets::Faye::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
         else
           logger.error %Q{Can't find a WebSockets backend. At the moment we only support

--- a/lib/padrino-websockets.rb
+++ b/lib/padrino-websockets.rb
@@ -14,27 +14,27 @@ module Padrino
       def registered(app)
         require 'padrino-websockets/base-event-manager'
         require 'padrino-websockets/pub_sub'
-        # set default pubsub to in-memory.  initializer can override with a different
-        # implementation
+        # set default pubsub to in-memory.  setting can override with a different
+        # implementation in your app settings
+        # example:
+        # set :websockets_pub_sub, SomeWeirdPubSub.new
+        #
+        unless app.respond_to?(:websockets_pub_sub)
+          app.set :websockets_pub_sub, Padrino::WebSockets::PubSub.new
+        end
 
         if defined?(::SpiderGazelle)
           require 'padrino-websockets/spider-gazelle'
           app.helpers Padrino::WebSockets::SpiderGazelle::Helpers
           app.extend Padrino::WebSockets::SpiderGazelle::Routing
-          
-          # set default pubsub to in-memory.  initializer can override with a different
-          # implementation
-          Padrino::WebSockets::SpiderGazelle::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
+          Padrino::WebSockets::SpiderGazelle::EventManager.pub_sub = app.websockets_pub_sub
         elsif defined?(::Faye::WebSocket)
           require 'padrino-websockets/faye'
           ::Faye::WebSocket.load_adapter('thin') if defined?(::Thin)
           require 'padrino-websockets/faye/puma-patch' if defined?(Puma)
           app.helpers Padrino::WebSockets::Faye::Helpers
           app.extend Padrino::WebSockets::Faye::Routing
-
-          # set default pubsub to in-memory.  initializer can override with a different
-          # implementation
-          Padrino::WebSockets::Faye::EventManager.pub_sub = Padrino::WebSockets::PubSub.new
+          Padrino::WebSockets::Faye::EventManager.pub_sub = app.websockets_pub_sub
         else
           logger.error %Q{Can't find a WebSockets backend. At the moment we only support
             SpiderGazelle and Faye Websockets friendly application backends (Puma and Thin work,

--- a/lib/padrino-websockets/base-event-manager.rb
+++ b/lib/padrino-websockets/base-event-manager.rb
@@ -133,7 +133,7 @@ module Padrino
 
         # all external calls *MUST* pass through pub-sub machinary.  
         # this allows ws outbound messages to get distributed to other
-        # servers/processes.  the pubsub impl is responsible from 
+        # servers/processes.
 
         def broadcast(channel, message, except=[])
           @@pub_sub.broadcast(channel, message, except)
@@ -175,13 +175,11 @@ module Padrino
           raise NotImplementedError
         end
 
+        # set active pubsub impl.  there is a 2-way handshake because the pub-sub
+        # impl *must* be able to forward messages to local websocket connections
         def pub_sub=(pub_sub)
           @@pub_sub = pub_sub
           @@pub_sub.event_manager = self
-        end
-
-        def pub_sub
-          @@pub_sub
         end
       end
 

--- a/lib/padrino-websockets/base-event-manager.rb
+++ b/lib/padrino-websockets/base-event-manager.rb
@@ -150,6 +150,11 @@ module Padrino
         def broadcast_local(channel, message, except=[])
           logger.debug "Broadcasting message on channel: #{channel}. Message:"
           logger.debug message
+          if @@connections[channel].nil?
+            logger.error "channel not configured: #{channel}"
+            return nil
+          end
+
           @@connections[channel].each do |user, ws|
             next if except.include?(user)
             write message, ws
@@ -162,6 +167,11 @@ module Padrino
         #
         def send_message_local(channel, user, message)
           logger.debug "Sending message: #{message} to user: #{user} on channel: #{channel}. Message"
+          if @@connections[channel].nil?
+            logger.error "channel not configured: #{channel}"
+            return nil
+          end
+
           write message, @@connections[channel][user]
         end
 

--- a/lib/padrino-websockets/base-event-manager.rb
+++ b/lib/padrino-websockets/base-event-manager.rb
@@ -10,6 +10,9 @@ module Padrino
         runtime: "Error while running the event handler"
       }
 
+      @@pub_sub = nil
+      @@connections = {}
+
       ##
       # Creates a new WebSocket manager for a specific connection with a user on a channel.
       #
@@ -29,7 +32,6 @@ module Padrino
         @channel = channel
         @user = user
         @ws = ws
-        @@connections ||= {}
         @@connections[@channel] ||= {}
         @@connections[@channel][@user] = @ws
 
@@ -128,11 +130,24 @@ module Padrino
       end
 
       class << self
+
+        # all external calls *MUST* pass through pub-sub machinary.  
+        # this allows ws outbound messages to get distributed to other
+        # servers/processes.  the pubsub impl is responsible from 
+
+        def broadcast(channel, message, except=[])
+          @@pub_sub.broadcast(channel, message, except)
+        end
+
+        def send_message(channel, user, message)
+          @@pub_sub.send_message(channel, user, message)
+        end
+
         ##
         # Broadcast a message to the whole channel.
         # Can be used to access it outside the router's scope, for instance, in a background process.
         #
-        def broadcast(channel, message, except=[])
+        def broadcast_local(channel, message, except=[])
           logger.debug "Broadcasting message on channel: #{channel}. Message:"
           logger.debug message
           @@connections[channel].each do |user, ws|
@@ -145,7 +160,7 @@ module Padrino
         # Send a message to a user on the channel
         # Can be used to access it outside the router's scope, for instance, in a background process.
         #
-        def send_message(channel, user, message)
+        def send_message_local(channel, user, message)
           logger.debug "Sending message: #{message} to user: #{user} on channel: #{channel}. Message"
           write message, @@connections[channel][user]
         end
@@ -159,7 +174,17 @@ module Padrino
           logger.error "Override the write method on the WebSocket-specific backend."
           raise NotImplementedError
         end
+
+        def pub_sub=(pub_sub)
+          @@pub_sub = pub_sub
+          @@pub_sub.event_manager = self
+        end
+
+        def pub_sub
+          @@pub_sub
+        end
       end
+
 
       protected
         ##

--- a/lib/padrino-websockets/pub_sub.rb
+++ b/lib/padrino-websockets/pub_sub.rb
@@ -1,0 +1,30 @@
+module Padrino
+  module WebSockets
+    class PubSub
+
+      # default impl is in-memory
+      # in order to provide another 
+
+      def initialize
+      end
+
+      def event_manager=(event_manager)
+        @event_manager = event_manager
+      end
+
+      def event_manager()
+        @event_manager
+      end
+
+      def broadcast(channel, message, except=[])
+        @event_manager.broadcast_local(channel, message, except)
+      end
+
+      def send_message(channel, user, message)
+        @event_manager.send_message_local(channel, user, message)
+      end
+
+
+    end
+  end
+end

--- a/lib/padrino-websockets/pub_sub.rb
+++ b/lib/padrino-websockets/pub_sub.rb
@@ -2,29 +2,32 @@ module Padrino
   module WebSockets
     class PubSub
 
-      # default impl is in-memory
-      # in order to provide another 
+      # default in-memory pubsub other implementations must conform to the same
+      # method signatures:
+      # event_manager=
+      # broadcast
+      # send_message
 
-      def initialize
-      end
-
+      # hold on to reference of local even manager type
+      # use this to forward messages to local websocket connections
       def event_manager=(event_manager)
         @event_manager = event_manager
       end
 
-      def event_manager()
-        @event_manager
-      end
-
+      # handle broadcast messages
+      # note:  alternate implementations should *NOT* send to a pub-sub systems *AND*
+      # local event manager.  it causes duplicate message propogation to local websocket
+      # connections
       def broadcast(channel, message, except=[])
         @event_manager.broadcast_local(channel, message, except)
       end
 
+      # note:  alternate implementations should *NOT* send to a pub-sub systems *AND*
+      # local event manager.  it causes duplicate message propogation to local websocket
+      # connections
       def send_message(channel, user, message)
         @event_manager.send_message_local(channel, user, message)
       end
-
-
     end
   end
 end

--- a/lib/padrino-websockets/version.rb
+++ b/lib/padrino-websockets/version.rb
@@ -1,5 +1,5 @@
 module Padrino
   module Websockets
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end

--- a/padrino-websockets.gemspec
+++ b/padrino-websockets.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "oj"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
i like the module. I needed a way to distribute websocket messages/broadcasts across processes.  I plan to use redis pubsub for that.   if there is interest, i could include the redis PubSub in this gem or keep it separate in my app (or another gem).

Cheers,  Kevin